### PR TITLE
fix: move oapilib to dev deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,13 +13,13 @@
     "prepublish": "in-publish && yarn build || echo Skipping build."
   },
   "devDependencies": {
+    "@insertish/oapi": "0.1.18",
     "@types/lodash.defaultsdeep": "^4.6.6",
     "in-publish": "^2.0.1",
     "openapi-typescript": "^5.2.0",
     "typescript": "^4.6.2"
   },
   "dependencies": {
-    "@insertish/oapi": "0.1.18",
     "axios": "^0.26.1",
     "lodash.defaultsdeep": "^4.6.1"
   },


### PR DESCRIPTION
## Please make sure to check the following tasks before opening and submitting a PR

* [x] I understand and have followed the [contribution guide](https://github.com/revoltchat/revolt/discussions/282)
* [x] I have tested my changes locally and they are working as intended
* [x] These changes do not have any notable side effects on other Revolt projects

This removes the `@insertish/oapi` package from regular installs, reducing the package's overall size. This should not affect the CI pipeline which relies on it as it installs every dependency.